### PR TITLE
refactor: ignore input blur

### DIFF
--- a/alwaysonfocus.user.js
+++ b/alwaysonfocus.user.js
@@ -23,7 +23,10 @@ Object.defineProperty(document, 'visibilityState', { get: function () { return "
 unsafeWindow.document.onvisibilitychange = undefined;
 
 for (const event_name of ["visibilitychange", "webkitvisibilitychange", "blur", "mozvisibilitychange", "msvisibilitychange"]) {
-  window.addEventListener(event_name, function(event) {
+    window.addEventListener(event_name, function (event) {
+        if (event.type === 'blur' && event.target instanceof HTMLInputElement) {
+            return;
+        }
         event.stopImmediatePropagation();
     }, true);
 }


### PR DESCRIPTION
Some sites will use blur on the input box to implement functions such as trim.
After the fix, the password box on [this page](https://developer.mozilla.org/en-US/docs/Web/API/Element/blur_event#result) is back to normal.