### PR TITLE
fix: classList null safety

### DIFF
--- a/alwaysonfocus.user.js
+++ b/alwaysonfocus.user.js
@@ -55,7 +55,7 @@ var event_handler = (event) => {
     // if the event is blur, and the target is an whitelisted type, allow it
     if (event.type === 'blur' &&
         ((blurWhitelist.some(type => event.target instanceof type) ||
-            event.target.classList.contains('ql-editor')))) { // quill js fix
+            event.target.classList?.contains('ql-editor')))) { // quill js fix
         return;
     }
     // if the event is mouseleave or mouseout, and the target is an blacklisted type, block it


### PR DESCRIPTION
In situations where classList was was not defined, this error would bork the userscript. Just make it null safe. 