### PR TITLE
Override `onfocus` (closes #8)

### DIFF
--- a/alwaysonfocus.user.js
+++ b/alwaysonfocus.user.js
@@ -2,7 +2,7 @@
 // @name          Always on focus
 // @namespace     https://github.com/daijro/always-on-focus
 // @author        daijro
-// @version       1.5.3
+// @version       1.5.4
 // @description   Prevents websites from knowing that you switched tabs or unfocused the window
 // @include       *
 // @updateURL     https://github.com/daijro/always-on-focus/raw/main/alwaysonfocus.user.js

--- a/alwaysonfocus.user.js
+++ b/alwaysonfocus.user.js
@@ -16,6 +16,7 @@ unsafeWindow.blurred = false;
 
 unsafeWindow.document.hasFocus = () => true;
 unsafeWindow.window.onFocus = () => true;
+unsafeWindow.window.onfocus = () => true;
 
 // kill dom property names
 [


### PR DESCRIPTION
#8 [cites a website](https://www.proginosko.com/test/WindowFocusEvents.html) that uses the `onfocus` event, which is not overridden by this script (it only overrides `onFocus`).